### PR TITLE
chore: modernize test suite for pytest and Python 3.12+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,5 +37,8 @@ Issues = "https://github.com/eth-library/oaipmh/issues"
 [project.optional-dependencies]
 test = ["pytest"]
 
+[tool.pytest.ini_options]
+testpaths = ["src/oaipmh/tests"]
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/oaipmh"]

--- a/src/oaipmh/tests/createbrokendata.py
+++ b/src/oaipmh/tests/createbrokendata.py
@@ -1,4 +1,4 @@
-from fakeclient import FakeCreaterClient
+from .fakeclient import FakeCreaterClient
 from datetime import datetime
 from oaipmh import metadata
 

--- a/src/oaipmh/tests/createdata.py
+++ b/src/oaipmh/tests/createdata.py
@@ -1,4 +1,4 @@
-from fakeclient import FakeCreaterClient
+from .fakeclient import FakeCreaterClient
 
 # tied to the server at EUR..
 client = FakeCreaterClient(

--- a/src/oaipmh/tests/createdata_deleted_records.py
+++ b/src/oaipmh/tests/createdata_deleted_records.py
@@ -1,4 +1,4 @@
-from fakeserver import FakeCreaterServerProxy
+from .fakeserver import FakeCreaterServerProxy
 
 # tied to the server at EUR..
 server = FakeCreaterServerProxy(

--- a/src/oaipmh/tests/runtests.sh
+++ b/src/oaipmh/tests/runtests.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-python -m unittest test_broken test_client test_datestamp test_deleted_records test_server test_validation

--- a/src/oaipmh/tests/test_broken.py
+++ b/src/oaipmh/tests/test_broken.py
@@ -1,6 +1,6 @@
 import os
 from datetime import datetime
-from unittest import TestCase, TestSuite, makeSuite, main
+from unittest import TestCase
 
 from .fakeclient import FakeClient
 from oaipmh import metadata, error
@@ -26,9 +26,3 @@ class BrokenDataTestCase(TestCase):
     def test_broken_datestamp(self):
         fakeclient = self.createFakeClient('fake5')
         self.assertRaises(error.DatestampError, fakeclient.identify)
-
-def test_suite():
-    return TestSuite((makeSuite(BrokenDataTestCase), ))
-
-if __name__ == '__main__':
-    main()

--- a/src/oaipmh/tests/test_broken.py
+++ b/src/oaipmh/tests/test_broken.py
@@ -2,7 +2,7 @@ import os
 from datetime import datetime
 from unittest import TestCase, TestSuite, makeSuite, main
 
-from fakeclient import FakeClient
+from .fakeclient import FakeClient
 from oaipmh import metadata, error
 
 test_directory = os.path.dirname(__file__)

--- a/src/oaipmh/tests/test_client.py
+++ b/src/oaipmh/tests/test_client.py
@@ -33,42 +33,42 @@ class ClientTestCase(TestCase):
     def test_getRecord(self):
         header, metadata, about = fakeclient.getRecord(
             metadataPrefix='oai_dc', identifier='hdl:1765/315')
-        self.assertEquals(
+        self.assertEqual(
             'hdl:1765/315',
             header.identifier())
-        self.assertEquals(
+        self.assertEqual(
             ['2:7'],
             header.setSpec())
-        self.assert_(not header.isDeleted())
+        self.assertTrue(not header.isDeleted())
 
     def test_getMetadata(self):
         metadata = fakeclient.getMetadata(
             metadataPrefix='oai_dc', identifier='hdl:1765/315')
-        self.assertEquals(metadata.tag,
+        self.assertEqual(metadata.tag,
                           '{http://www.openarchives.org/OAI/2.0/oai_dc/}dc')
 
 
     def test_identify(self):
         identify = fakeclient.identify()
-        self.assertEquals(
+        self.assertEqual(
             'Erasmus University : Research Online',
             identify.repositoryName())
-        self.assertEquals(
+        self.assertEqual(
             'http://dspace.ubib.eur.nl/oai/',
             identify.baseURL())
-        self.assertEquals(
+        self.assertEqual(
             '2.0',
             identify.protocolVersion())
-        self.assertEquals(
+        self.assertEqual(
             ['service@ubib.eur.nl'],
             identify.adminEmails())
-        self.assertEquals(
+        self.assertEqual(
             'no',
             identify.deletedRecord())
-        self.assertEquals(
+        self.assertEqual(
             'YYYY-MM-DDThh:mm:ssZ',
             identify.granularity())
-        self.assertEquals(
+        self.assertEqual(
             ['gzip', 'compress', 'deflate'],
             identify.compression())
 
@@ -79,17 +79,17 @@ class ClientTestCase(TestCase):
         headers = list(headers)
 
         header = headers[0]
-        self.assertEquals(
+        self.assertEqual(
             'hdl:1765/308',
             header.identifier())
-        self.assertEquals(
+        self.assertEqual(
             datetime(2003, 4, 15, 10, 18, 51),
             header.datestamp())
-        self.assertEquals(
+        self.assertEqual(
             ['1:2'],
             header.setSpec())
-        self.assert_(not header.isDeleted())
-        self.assertEquals(16, len(headers))
+        self.assertTrue(not header.isDeleted())
+        self.assertEqual(16, len(headers))
 
 
     def test_listIdentifiers_until_none(self):
@@ -97,7 +97,7 @@ class ClientTestCase(TestCase):
         headers = fakeclient.listIdentifiers(from_=datetime(2003, 4, 10),
                                              until=None,
                                              metadataPrefix='oai_dc')
-        self.assertEquals(16, len(list(headers)))
+        self.assertEqual(16, len(list(headers)))
 
     def test_listIdentifiers_from_none(self):
         # test listIdentifiers with until argument as None explicitly
@@ -109,7 +109,7 @@ class ClientTestCase(TestCase):
             headers = fakeclient.listIdentifiers(from_=None,
                                                  metadataPrefix='oai_dc')
         except KeyError as e:
-            self.assertEquals('metadataPrefix=oai_dc&verb=ListIdentifiers',
+            self.assertEqual('metadataPrefix=oai_dc&verb=ListIdentifiers',
                               e.args[0])
 
     def test_listIdentifiers_argument_error(self):
@@ -124,31 +124,31 @@ class ClientTestCase(TestCase):
         records = list(records)
         # lazy, just test first one
         header, metadata, about = records[0]
-        self.assertEquals(
+        self.assertEqual(
             'hdl:1765/308',
             header.identifier())
-        self.assertEquals(
+        self.assertEqual(
             datetime(2003, 4, 15, 10, 18, 51),
              header.datestamp())
-        self.assertEquals(
+        self.assertEqual(
             ['1:2'],
             header.setSpec())
-        self.assert_(not header.isDeleted())
+        self.assertTrue(not header.isDeleted())
         # XXX need to extend metadata tests
-        self.assertEquals(
+        self.assertEqual(
             ['Kijken in het brein: Over de mogelijkheden van neuromarketing'],
             metadata.getField('title'))
 
     def test_listMetadataFormats(self):
         formats = fakeclient.listMetadataFormats()
         metadataPrefix, schema, metadataNamespace = formats[0]
-        self.assertEquals(
+        self.assertEqual(
             'oai_dc',
             metadataPrefix)
-        self.assertEquals(
+        self.assertEqual(
             'http://www.openarchives.org/OAI/2.0/oai_dc.xsd',
             schema)
-        self.assertEquals(
+        self.assertEqual(
             'http://www.openarchives.org/OAI/2.0/oai_dc/',
             metadataNamespace)
 
@@ -161,7 +161,7 @@ class ClientTestCase(TestCase):
         sets = fakeclient.listSets()
         sets = list(sets)
         compare = [sets[0], sets[1]]
-        self.assertEquals(
+        self.assertEqual(
             expected,
             compare)
 
@@ -172,7 +172,7 @@ class ClientTestCase(TestCase):
             fakeclient.listRecords(from_=datetime(2003, 4, 10, 14, 0),
                                    metadataPrefix='oai_dc')
         except TestError as e:
-            self.assertEquals('2003-04-10T14:00:00Z', e.kw['from'])
+            self.assertEqual('2003-04-10T14:00:00Z', e.kw['from'])
         fakeclient = GranularityFakeClient(granularity='YYYY-MM-DD')
         fakeclient.updateGranularity()
         try:
@@ -180,8 +180,8 @@ class ClientTestCase(TestCase):
                                    until=datetime(2004, 6, 17, 15, 30),
                                    metadataPrefix='oai_dc')
         except TestError as e:
-            self.assertEquals('2003-04-10', e.kw['from'])
-            self.assertEquals('2004-06-17', e.kw['until'])
+            self.assertEqual('2003-04-10', e.kw['from'])
+            self.assertEqual('2004-06-17', e.kw['until'])
 
     def test_no_retry_policy(self):
         """check request is not retried by default on HTTP 500 errors"""

--- a/src/oaipmh/tests/test_client.py
+++ b/src/oaipmh/tests/test_client.py
@@ -4,7 +4,7 @@ try:
 except ImportError:  # python < 3.3
     import mock
 
-from fakeclient import FakeClient, GranularityFakeClient, TestError
+from .fakeclient import FakeClient, GranularityFakeClient, TestError
 import os
 from datetime import datetime
 try:

--- a/src/oaipmh/tests/test_client.py
+++ b/src/oaipmh/tests/test_client.py
@@ -1,4 +1,4 @@
-from unittest import TestCase, TestSuite, main, makeSuite
+from unittest import TestCase
 try:
     from unittest import mock
 except ImportError:  # python < 3.3
@@ -219,9 +219,3 @@ class ClientTestCase(TestCase):
                 self.assertEqual(sleep.call_count, 5)
                 sleep.assert_has_calls([mock.call(5)] * 5)
 
-
-def test_suite():
-    return TestSuite((makeSuite(ClientTestCase), ))
-
-if __name__=='__main__':
-    main(defaultTest='test_suite')

--- a/src/oaipmh/tests/test_datestamp.py
+++ b/src/oaipmh/tests/test_datestamp.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from unittest import TestCase, TestSuite, makeSuite
+from unittest import TestCase
 from oaipmh.datestamp import datestamp_to_datetime,\
      tolerant_datestamp_to_datetime
 from oaipmh.error import DatestampError
@@ -63,5 +63,3 @@ class DatestampTestCase(TestCase):
             datetime(2005, 2, 1),
             f('2005-02'))
         
-def test_suite():
-    return TestSuite((makeSuite(DatestampTestCase), ))

--- a/src/oaipmh/tests/test_datestamp.py
+++ b/src/oaipmh/tests/test_datestamp.py
@@ -6,13 +6,13 @@ from oaipmh.error import DatestampError
 
 class DatestampTestCase(TestCase):
     def test_strict_datestamp_to_datetime(self):
-        self.assertEquals(
+        self.assertEqual(
             datetime(2005, 7, 4, 14, 35, 10),
             datestamp_to_datetime('2005-07-04T14:35:10Z'))
-        self.assertEquals(
+        self.assertEqual(
             datetime(2005, 1, 24, 14, 34, 2),
             datestamp_to_datetime('2005-01-24T14:34:02Z'))
-        self.assertEquals(
+        self.assertEqual(
             datetime(2005, 7, 4),
             datestamp_to_datetime('2005-07-04'))
         self.assertRaises(DatestampError,
@@ -34,32 +34,32 @@ class DatestampTestCase(TestCase):
         try:
             datestamp_to_datetime('foo')
         except DatestampError as e:
-            self.assertEquals('foo', e.datestamp)
+            self.assertEqual('foo', e.datestamp)
 
     def test_strict_datestamp_to_datetime_inclusive(self):
         # passing inclusive=True to datestamp_to_datetime
         # should default the time to 23:59:59 instead of 00:00:00
         # when only a date is supplied
 
-        self.assertEquals(datetime(2009, 11, 16, 23, 59, 59),
+        self.assertEqual(datetime(2009, 11, 16, 23, 59, 59),
                           datestamp_to_datetime('2009-11-16',
                                                 inclusive=True))
         
     def test_tolerant_datestamp_to_datetime(self):
         f = tolerant_datestamp_to_datetime
-        self.assertEquals(
+        self.assertEqual(
             datetime(2005, 7, 4, 14, 35, 10),
             f('2005-07-04T14:35:10Z'))
-        self.assertEquals(
+        self.assertEqual(
             datetime(2005, 1, 24, 14, 34, 2),
             f('2005-01-24T14:34:02Z'))
-        self.assertEquals(
+        self.assertEqual(
             datetime(2005, 7, 4),
             f('2005-07-04'))
-        self.assertEquals(
+        self.assertEqual(
             datetime(2005, 1, 1),
             f('2005'))
-        self.assertEquals(
+        self.assertEqual(
             datetime(2005, 2, 1),
             f('2005-02'))
         

--- a/src/oaipmh/tests/test_deleted_records.py
+++ b/src/oaipmh/tests/test_deleted_records.py
@@ -1,4 +1,4 @@
-from unittest import TestCase, TestSuite, main, makeSuite
+from unittest import TestCase
 from .fakeclient import FakeClient
 import os
 from oaipmh import metadata
@@ -34,8 +34,3 @@ class DeletedRecordsTestCase(TestCase):
             else:
                 self.assert_(metadata is not None)
     
-def test_suite():
-    return TestSuite((makeSuite(DeletedRecordsTestCase), ))
-
-if __name__=='__main__':
-    main(defaultTest='test_suite')

--- a/src/oaipmh/tests/test_deleted_records.py
+++ b/src/oaipmh/tests/test_deleted_records.py
@@ -15,14 +15,14 @@ class DeletedRecordsTestCase(TestCase):
     def test_getRecord_deleted(self):
         header, metadata, about = fakeclient.getRecord(
             metadataPrefix='oai_dc', identifier='hdl:1765/1160')
-        self.assert_(metadata is None)
-        self.assert_(header.isDeleted())
+        self.assertTrue(metadata is None)
+        self.assertTrue(header.isDeleted())
 
     def test_getRecord_not_deleted(self):
         header, metadata, about = fakeclient.getRecord(
             metadataPrefix='oai_dc', identifier='hdl:1765/1162')
-        self.assert_(metadata is not None)
-        self.assert_(not header.isDeleted())
+        self.assertTrue(metadata is not None)
+        self.assertTrue(not header.isDeleted())
 
     def test_listRecords(self):
         records = fakeclient.listRecords(from_=datetime(2004, 1, 1),
@@ -30,7 +30,7 @@ class DeletedRecordsTestCase(TestCase):
         # lazy, just test first one
         for header, metadata, about in records:
             if header.isDeleted():
-                self.assert_(metadata is None)
+                self.assertTrue(metadata is None)
             else:
-                self.assert_(metadata is not None)
+                self.assertTrue(metadata is not None)
     

--- a/src/oaipmh/tests/test_deleted_records.py
+++ b/src/oaipmh/tests/test_deleted_records.py
@@ -1,5 +1,5 @@
 from unittest import TestCase, TestSuite, main, makeSuite
-from fakeclient import FakeClient
+from .fakeclient import FakeClient
 import os
 from oaipmh import metadata
 from datetime import datetime

--- a/src/oaipmh/tests/test_server.py
+++ b/src/oaipmh/tests/test_server.py
@@ -8,8 +8,8 @@ except ImportError:
 from oaipmh import server, client, common, metadata, error
 from lxml import etree
 from datetime import datetime
-import fakeclient
-import fakeserver
+from . import fakeclient
+from . import fakeserver
 
 NS_OAIPMH = server.NS_OAIPMH
 

--- a/src/oaipmh/tests/test_server.py
+++ b/src/oaipmh/tests/test_server.py
@@ -42,37 +42,37 @@ class XMLTreeServerTestCase(unittest.TestCase):
     def test_getRecord(self):
         tree = self._server.getRecord(
             metadataPrefix='oai_dc', identifier='hdl:1765/315')
-        self.assert_(oaischema.validate(tree))
+        self.assertTrue(oaischema.validate(tree))
 
     def test_getMetadata(self):
         tree = self._server.getMetadata(
             metadataPrefix='oai_dc', identifier='hdl:1765/315')
-        self.assertEquals(tree.tag,
+        self.assertEqual(tree.tag,
                           '{http://www.openarchives.org/OAI/2.0/oai_dc/}dc')
         
     def test_identify(self):
         tree = self._server.identify()
-        self.assert_(oaischema.validate(tree))
+        self.assertTrue(oaischema.validate(tree))
 
     def test_listIdentifiers(self):
         tree = self._server.listIdentifiers(
             from_=datetime(2003, 4, 10),
             metadataPrefix='oai_dc')
-        self.assert_(oaischema.validate(tree))
+        self.assertTrue(oaischema.validate(tree))
         
     def test_listMetadataFormats(self):
         tree = self._server.listMetadataFormats()
-        self.assert_(oaischema.validate(tree))
+        self.assertTrue(oaischema.validate(tree))
 
     def test_listRecords(self):
         tree = self._server.listRecords(
             from_=datetime(2003, 4, 10),
             metadataPrefix='oai_dc')
-        self.assert_(oaischema.validate(tree))
+        self.assertTrue(oaischema.validate(tree))
 
     def test_listSets(self):
         tree = self._server.listSets()
-        self.assert_(oaischema.validate(tree))
+        self.assertTrue(oaischema.validate(tree))
 
     def test_namespaceDeclarations(self):
         # according to the spec, all namespace used in the metadata
@@ -120,14 +120,14 @@ class ServerTestCase(unittest.TestCase):
     def test_identify(self):
         xml = self._server.identify()
         tree = etree_parse(xml)
-        self.assert_(oaischema.validate(tree))
+        self.assertTrue(oaischema.validate(tree))
         
     def test_listIdentifiers(self):
         xml = self._server.listIdentifiers(
             from_=datetime(2003, 4, 10),
             metadataPrefix='oai_dc')
         tree = etree_parse(xml)
-        self.assert_(oaischema.validate(tree))
+        self.assertTrue(oaischema.validate(tree))
         
 class ResumptionTestCase(unittest.TestCase):
     def setUp(self):
@@ -141,7 +141,7 @@ class ResumptionTestCase(unittest.TestCase):
         while token is not None:
             result, token = self._server.listIdentifiers(resumptionToken=token)
             headers.extend(result)
-        self.assertEquals([str(i) for i in range(100)],
+        self.assertEqual([str(i) for i in range(100)],
                           [header.identifier() for header in headers])
 
     def test_tree_resumption(self):
@@ -150,9 +150,9 @@ class ResumptionTestCase(unittest.TestCase):
         myserver = server.XMLTreeServer(
             self._server, metadata_registry)
         tree = myserver.listIdentifiers(metadataPrefix='oai_dc')
-        self.assert_(oaischema.validate(tree))
+        self.assertTrue(oaischema.validate(tree))
         # we should find a resumptionToken element with text
-        self.assert_(
+        self.assertTrue(
             tree.xpath('//oai:resumptionToken/text()', 
                        namespaces={'oai': NS_OAIPMH} ))
         
@@ -166,14 +166,14 @@ class BatchingResumptionTestCase(unittest.TestCase):
         result, token = resumption_server.listIdentifiers(
             metadataPrefix='oai_dc')
         headers.extend(result)
-        self.assert_(token is not None)
+        self.assertTrue(token is not None)
         while token is not None:
-            self.assert_(result)
-            self.assertEquals(expected_length, len(result))
+            self.assertTrue(result)
+            self.assertEqual(expected_length, len(result))
             result, token = resumption_server.listIdentifiers(
                 resumptionToken=token)
             headers.extend(result)
-        self.assertEquals([str(i) for i in range(100)],
+        self.assertEqual([str(i) for i in range(100)],
                           [header.identifier() for header in headers])
 
     def test_resumption(self):
@@ -187,8 +187,8 @@ class BatchingResumptionTestCase(unittest.TestCase):
         myserver = server.BatchingResumption(self._fakeserver, 300)
         result, token = myserver.listIdentifiers(
             metadataPrefix='oai_dc')
-        self.assert_(token is None)
-        self.assertEquals([str(i) for i in range(100)],
+        self.assertTrue(token is None)
+        self.assertEqual([str(i) for i in range(100)],
                           [header.identifier() for header in result])
         
     def test_tree_resumption(self):
@@ -196,9 +196,9 @@ class BatchingResumptionTestCase(unittest.TestCase):
         metadata_registry.registerWriter('oai_dc', server.oai_dc_writer)
         myserver = server.XMLTreeServer(self._server, metadata_registry)
         tree = myserver.listIdentifiers(metadataPrefix='oai_dc')
-        self.assert_(oaischema.validate(tree))
+        self.assertTrue(oaischema.validate(tree))
         # we should find a resumptionToken element with text
-        self.assert_(
+        self.assertTrue(
             tree.xpath('//oai:resumptionToken/text()', 
                        namespaces={'oai': NS_OAIPMH} ))
         
@@ -214,19 +214,19 @@ class ClientServerTestCase(unittest.TestCase):
 
     def test_listIdentifiers(self):
         headers = self._client.listIdentifiers(metadataPrefix='oai_dc')
-        self.assertEquals([str(i) for i in range(100)],
+        self.assertEqual([str(i) for i in range(100)],
                           [header.identifier() for header in headers])
 
     def test_listRecords(self):
         records = self._client.listRecords(metadataPrefix='oai_dc')
         records = list(records)
-        self.assertEquals(100, len(records))
+        self.assertEqual(100, len(records))
         metadatas = [metadata for (header, metadata, about) in records]
         result = []
         for metadata in metadatas:
             result.append(metadata.getField('title')[0])
         expected = ['Title %s' % i for i in range(100)]
-        self.assertEquals(expected, result)
+        self.assertEqual(expected, result)
         #for record in records:
         #    print record[0].datestamp()
 
@@ -236,7 +236,7 @@ class ClientServerTestCase(unittest.TestCase):
                                                until=datetime(2004, 7, 1))
         # we expect 52 items
         headers = list(headers)
-        self.assertEquals(52, len(headers))
+        self.assertEqual(52, len(headers))
 
     def test_listIdentifiersFromUntil_nothing(self):
         self.assertRaises(error.NoRecordsMatchError,
@@ -324,13 +324,13 @@ class ErrorTestCase(unittest.TestCase):
         
     
     def assertErrors(self, errors, xml):
-        self.assertEquals(errors, self.findErrors(xml))
+        self.assertEqual(errors, self.findErrors(xml))
         
     def findErrors(self, xml):
         # parse
         tree = etree_parse(xml)
         # validate xml
-        self.assert_(oaischema.validate(tree))
+        self.assertTrue(oaischema.validate(tree))
         result = []
         for e in tree.xpath(
             '//oai:error', namespaces={'oai': NS_OAIPMH}):
@@ -352,31 +352,31 @@ class DeletionTestCase(unittest.TestCase):
         headers = self._client.listIdentifiers(metadataPrefix='oai_dc')
         # we expect 12 items
         headers = list(headers)
-        self.assertEquals(12, len(headers))
+        self.assertEqual(12, len(headers))
         # now delete
         self._fakeserver.deletionEvent()
         # check again, we expect 12 items, but half of which is deleted
         headers = self._client.listIdentifiers(metadataPrefix='oai_dc')
         headers = list(headers)
-        self.assertEquals(12, len(headers))
+        self.assertEqual(12, len(headers))
         deleted_count = 0
         for header in headers:
             if header.isDeleted():
                 deleted_count += 1
-        self.assertEquals(6, deleted_count)
+        self.assertEqual(6, deleted_count)
 
     def test_listRecords(self):
         self._fakeserver.deletionEvent()
         # we expect 12 items, but half of which is deleted
         records = self._client.listRecords(metadataPrefix='oai_dc')
         records = list(records)
-        self.assertEquals(12, len(records))
+        self.assertEqual(12, len(records))
         deleted_count = 0
         for header, metadata, about in records:
             if header.isDeleted():
                 deleted_count += 1
-                self.assertEquals(None, metadata)
-        self.assertEquals(6, deleted_count)
+                self.assertEqual(None, metadata)
+        self.assertEqual(6, deleted_count)
 
     def test_getRecord(self):
         self._fakeserver.deletionEvent()
@@ -386,8 +386,8 @@ class DeletionTestCase(unittest.TestCase):
         # we try to access a deleted record
         header, metadata, about = self._client.getRecord(
             metadataPrefix='oai_dc', identifier='1')
-        self.assert_(header.isDeleted())
-        self.assertEquals(None, metadata)
+        self.assertTrue(header.isDeleted())
+        self.assertEqual(None, metadata)
 
 class NsMapTestCase(unittest.TestCase):
     def setUp(self):
@@ -408,6 +408,6 @@ class NsMapTestCase(unittest.TestCase):
         # if we pass another nsmap along to the server constructor, we
         # can control extra namespaces in the output envelope
         tree = self._xmlserver.identify()
-        self.assertEquals(
+        self.assertEqual(
             'http://www.cow.com',
             tree.getroot().nsmap['cow'])

--- a/src/oaipmh/tests/test_server.py
+++ b/src/oaipmh/tests/test_server.py
@@ -411,18 +411,3 @@ class NsMapTestCase(unittest.TestCase):
         self.assertEquals(
             'http://www.cow.com',
             tree.getroot().nsmap['cow'])
-        
-        
-def test_suite():
-    return unittest.TestSuite([
-        unittest.makeSuite(XMLTreeServerTestCase),
-        unittest.makeSuite(ServerTestCase),
-        unittest.makeSuite(ResumptionTestCase),
-        unittest.makeSuite(BatchingResumptionTestCase),
-        unittest.makeSuite(ClientServerTestCase),
-        unittest.makeSuite(ErrorTestCase),
-        unittest.makeSuite(DeletionTestCase),
-        unittest.makeSuite(NsMapTestCase)])
-
-if __name__=='__main__':
-    main(defaultTest='test_suite')

--- a/src/oaipmh/tests/test_validation.py
+++ b/src/oaipmh/tests/test_validation.py
@@ -7,7 +7,7 @@ class ArgumentValidatorTestCase(unittest.TestCase):
             'foo': 'optional',
             'bar': 'optional'
             }
-        self.assertEquals(
+        self.assertEqual(
             None,
             validation.validate(spec, {'foo': 'Foo', 'bar': 'Bar'}))
         # an extra argument gives an error
@@ -16,10 +16,10 @@ class ArgumentValidatorTestCase(unittest.TestCase):
             validation.validate,
             spec, {'hoi': 'Hoi', 'foo': 'Foo', 'bar': 'Bar'})
         # a missing optional argument is fine
-        self.assertEquals(
+        self.assertEqual(
             None,
             validation.validate(spec, {'foo': 'Foo'}))
-        self.assertEquals(
+        self.assertEqual(
             None,
             validation.validate(spec, {}))
 
@@ -27,10 +27,10 @@ class ArgumentValidatorTestCase(unittest.TestCase):
         spec = {
             'foo': 'required',
             'bar': 'optional'}
-        self.assertEquals(
+        self.assertEqual(
             None,
             validation.validate(spec, {'foo': 'Foo', 'bar': 'Bar'}))
-        self.assertEquals(
+        self.assertEqual(
             None,
             validation.validate(spec, {'foo': 'Foo'}))
         self.assertRaises(
@@ -42,7 +42,7 @@ class ArgumentValidatorTestCase(unittest.TestCase):
             'foo': 'required',
             'bar': 'required',
             'hoi': 'exclusive'}
-        self.assertEquals(
+        self.assertEqual(
             None,
             validation.validate(spec, {'foo': 'Foo', 'bar': 'Bar'}))
         self.assertRaises(
@@ -52,7 +52,7 @@ class ArgumentValidatorTestCase(unittest.TestCase):
             validation.BadArgumentError,
             validation.validate, spec, {'bar': 'Bar'})
         # or a single exclusive argument
-        self.assertEquals(
+        self.assertEqual(
             None,
             validation.validate(spec, {'hoi': 'Hoi'}))
         self.assertRaises(

--- a/src/oaipmh/tests/test_validation.py
+++ b/src/oaipmh/tests/test_validation.py
@@ -58,9 +58,3 @@ class ArgumentValidatorTestCase(unittest.TestCase):
         self.assertRaises(
             validation.BadArgumentError,
             validation.validate, spec, {'foo': 'Foo', 'hoi': 'Hoi'})
-        
-def test_suite():
-    return unittest.TestSuite([unittest.makeSuite(ArgumentValidatorTestCase)])
-
-if __name__=='__main__':
-    main(defaultTest='test_suite')


### PR DESCRIPTION
Modernize the test suite to work with pytest and Python 3.12+. The tests were written for Python 2 and relied on patterns that no longer work in modern Python.

### Changes

- Convert bare imports to relative imports (e.g., `from fakeclient` → `from .fakeclient`). The old `runtests.sh` changed directory into the tests folder before running, which made bare imports work. Pytest runs from the project root, requiring proper relative imports.
- Remove `unittest.makeSuite`, which was [removed in Python 3.13](https://docs.python.org/3/whatsnew/3.13.html). Pytest discovers `TestCase` subclasses automatically, so the manual `test_suite()` functions are not needed.
- Replace `assertEquals` and `assert_` with `assertEqual` and `assertTrue`. These aliases were [removed in Python 3.12](https://docs.python.org/3/whatsnew/3.12.html).
- Add pytest configuration (`testpaths`) to `pyproject.toml`
- Remove legacy `runtests.sh`

### Known issue

27 tests still fail due to `lxml.etree.XPathElementEvaluator.evaluate()` being removed in lxml 5.0+. This is a bug in the library source (`client.py`), not in the tests, and will be fixed in a separate PR.