### PR TITLE
fix: runtime compatibility for lxml 5.0+ and Python 3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
 maintainers = [
     { name = "Jaime Cardozo", email = "jaime.cardozo@library.ethz.ch" },
 ]
-dependencies = ["lxml", "six"]
+dependencies = ["lxml"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Programming Language :: Python",

--- a/src/oaipmh/common.py
+++ b/src/oaipmh/common.py
@@ -7,10 +7,7 @@ class Header(object):
         self._element = element
         # force identifier to be a string, it might be 
         # an lxml.etree._ElementStringResult...
-        try:
-            self._identifier = str(identifier)
-        except UnicodeEncodeError:
-            self._identifier = unicode(identifier)
+        self._identifier = str(identifier)
         self._datestamp = datestamp
         self._setspec = setspec
         self._deleted = deleted

--- a/src/oaipmh/metadata.py
+++ b/src/oaipmh/metadata.py
@@ -1,13 +1,6 @@
-import sys
-
 from lxml import etree
 from lxml.etree import SubElement
 from oaipmh import common
-
-if sys.version_info[0] == 3:
-    text_type = str
-else:
-    text_type = unicode
 
 class MetadataRegistry(object):
     """A registry that contains readers and writers of metadata.
@@ -79,11 +72,11 @@ class MetadataReader(object):
             elif field_type == 'text':
                 # make sure we get back unicode strings instead
                 # of lxml.etree._ElementUnicodeResult objects.
-                value = text_type(e(expr))
+                value = str(e(expr))
             elif field_type == 'textList':
                 # make sure we get back unicode strings instead
                 # of lxml.etree._ElementUnicodeResult objects.
-                value = [text_type(v) for v in e(expr)]
+                value = [str(v) for v in e(expr)]
             else:
                 raise Error("Unknown field type: %s" % field_type)
             map[field_name] = value

--- a/src/oaipmh/metadata.py
+++ b/src/oaipmh/metadata.py
@@ -69,7 +69,7 @@ class MetadataReader(object):
         xpath_evaluator = etree.XPathEvaluator(element, 
                                                namespaces=self._namespaces)
         
-        e = xpath_evaluator.evaluate
+        e = xpath_evaluator
         # now extra field info according to xpath expr
         for field_name, (field_type, expr) in list(self._fields.items()):
             if field_type == 'bytes':

--- a/src/oaipmh/tests/test_server.py
+++ b/src/oaipmh/tests/test_server.py
@@ -1,10 +1,6 @@
 import unittest
 import os
-import six
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO, BytesIO
+from io import BytesIO
 from oaipmh import server, client, common, metadata, error
 from lxml import etree
 from datetime import datetime
@@ -21,9 +17,7 @@ def fileInTestDir(name):
 oaischema = etree.XMLSchema(etree.parse(fileInTestDir('OAI-PMH.xsd')))
 
 def etree_parse(xml):
-    if six.PY2:
-        return etree.parse(StringIO(xml))
-    return etree.parse(BytesIO(xml)) # .decode("utf-8")))
+    return etree.parse(BytesIO(xml))
 
 class XMLTreeServerTestCase(unittest.TestCase):
     
@@ -87,8 +81,7 @@ class XMLTreeServerTestCase(unittest.TestCase):
         # ugly xml manipulation, this is probably why the requirement is in
         # the spec (yuck!)
         xml = etree.tostring(tree)
-        if six.PY3:
-            xml = xml.decode("utf-8")
+        xml = xml.decode("utf-8")
         xml = xml.split('<metadata>')[-1].split('</metadata>')[0]
         first_el = xml.split('>')[0]
         self.assertTrue(first_el.startswith('<oai_dc:dc'))

--- a/uv.lock
+++ b/uv.lock
@@ -162,7 +162,6 @@ version = "2.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "lxml" },
-    { name = "six" },
 ]
 
 [package.optional-dependencies]
@@ -174,7 +173,6 @@ test = [
 requires-dist = [
     { name = "lxml" },
     { name = "pytest", marker = "extra == 'test'" },
-    { name = "six" },
 ]
 provides-extras = ["test"]
 
@@ -221,15 +219,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
-]
-
-[[package]]
-name = "six"
-version = "1.17.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Fixes three pre-existing runtime compatibility issues inherited from the abandoned upstream (infrae/pyoai).

The upstream code was written to support both Python 2 and 3 (using `six`, `unicode()`, and `try/except ImportError` patterns). It has not been maintained since March 2022, and lxml 5.0 — which removed the `XPathElementEvaluator.evaluate()` method used throughout the library — was released in January 2024. Since we introduced `uv lock` (PR #3), dependencies resolve to their latest compatible versions, pulling in lxml 5.x+ and surfacing these breakages.

### Changes

- **lxml 5.0+ fix:** Replace all `XPathElementEvaluator.evaluate()` calls with [direct callable syntax](https://lxml.de/5.0/changes-5.0.0.html) in `client.py` and `metadata.py`
- **Python 3 fix:** Replace `unicode()` (Python 2 builtin) with `str()` in `common.py` — see [What's New in Python 3.0](https://docs.python.org/3/whatsnew/3.0.html#text-vs-data-instead-of-unicode-vs-8-bit)
- **Remove `six`:** Replace all `six.text_type`/`six.PY2`/`six.PY3` usage with native Python 3 equivalents in `client.py`, `metadata.py`, and `test_server.py`; remove from `pyproject.toml` dependencies

These are strictly compatibility fixes — functionality and public API remain unchanged.

## Test plan
- [x] All 58 tests pass (`uv run pytest`)