### PR TITLE
infra: reproducible dev environment via Nix flake and direnv

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,11 @@
+use flake
+
+# Watch for changes to trigger environment reload
+watch_file pyproject.toml
+watch_file flake.nix
+watch_file flake.lock
+watch_file uv.lock
+
+# Setup Python dependencies
+uv sync --extra test --quiet || log_error "uv sync failed"
+PATH_add "$PWD/.venv/bin"

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1771903837,
+        "narHash": "sha256-sdaqdnsQCv3iifzxwB22tUwN/fSHoN7j2myFW5EIkGk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e764fc9a405871f1f6ca3d1394fb422e0a0c3951",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,31 @@
+{
+  description = "Nix flakes development environment for oaipmh";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
+    in
+    {
+      devShells = forAllSystems (pkgs: {
+        default = pkgs.mkShell {
+          packages = [
+            pkgs.python312
+            pkgs.uv
+          ];
+          LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [
+            pkgs.stdenv.cc.cc.lib
+          ];
+        };
+      });
+    };
+}


### PR DESCRIPTION
## Why Nix flakes?

[Nix flakes](https://wiki.nixos.org/wiki/Flakes) provide a fully reproducible, declarative development environment. Instead of relying on each developer's system-installed toolchain (which may differ in versions or configuration), the flake pins the exact nixpkgs revision in `flake.lock`, ensuring every contributor gets identical versions of Python, uv, and system libraries — regardless of OS or machine. This eliminates "works on my machine" issues and makes onboarding as simple as a single command.

## Summary

- Adds `flake.nix` providing a reproducible devShell with Python 3.12 and uv for all major platforms (x86_64/aarch64, Linux/macOS)
- Adds `.envrc` for [direnv](https://direnv.net/) integration — automatically loads the Nix shell, runs `uv sync --extra test`, and watches `pyproject.toml`, `flake.nix`, `flake.lock`, and `uv.lock` for reload
- Sets `LD_LIBRARY_PATH` for native C library resolution, needed for lxml's libxml2/libxslt bindings

## Usage

Nix is **not required** to contribute to this project — developers can continue using their own Python and uv setup. The flake is an optional convenience for those who want a reproducible, zero-setup environment.

Enter dev shell manually
```sh
nix develop
```
Or with direnv (automatic on cd)
```sh
direnv allow
```