### PR TITLE
fix(packaging): embed README as PyPI long description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.1] — 2026-04-15
+
+### Fixed
+
+- Embed `README.md` as the project's long description on PyPI. The PEP 621
+  `readme` field was missing from `pyproject.toml`, so the `oaipmh 3.0.0`
+  page on PyPI showed an empty body. No code or API changes; this is a
+  packaging-metadata-only fix.
+
 ## [3.0.0] — 2026-04-15
 
 First release under the `oaipmh` distribution name on PyPI. This release marks the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "oaipmh"
-version = "3.0.0"
+version = "3.0.1"
 description = "Python implementation of the Open Archives Initiative Protocol for Metadata Harvesting (OAI-PMH)"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ build-backend = "hatchling.build"
 name = "oaipmh"
 version = "3.0.0"
 description = "Python implementation of the Open Archives Initiative Protocol for Metadata Harvesting (OAI-PMH)"
+readme = "README.md"
 requires-python = ">=3.10"
 license = "BSD-3-Clause"
 authors = [


### PR DESCRIPTION
## Summary

Patch release fixing an empty project body on the PyPI project page for `oaipmh 3.0.0`. Pure packaging-metadata fix — no code or API changes.

## Root cause

`pyproject.toml` was missing the [PEP 621](https://peps.python.org/pep-0621/) `readme` field. Without it, [Hatchling](https://hatch.pypa.io/latest/config/metadata/#readme) produces a `PKG-INFO` with no `Description` section, so PyPI renders the project body empty — only the one-line `description` summary is visible.

`README.md` itself was already committed during the `v3.0.0` release work; it was simply never wired into the build metadata.

Evidence on PyPI for `oaipmh 3.0.0`:

- Project page: https://pypi.org/project/oaipmh/3.0.0/ (empty body)
- JSON confirms: `description_content_type: null`, `description_length: 0`

## Scope

Three atomic commits, two files — strictly the long-description fix:

- `fix: embed README.md as PyPI long description` — add `readme = "README.md"` to `pyproject.toml`.
- `chore: bump version to 3.0.1` — patch bump per [SemVer](https://semver.org/spec/v2.0.0.html) (PyPI releases are immutable, so the fix must ship as a new version).
- `docs: add [3.0.1] CHANGELOG entry`.

No code changes, no dependency changes, no API changes.

## Pre-PR verification

- `nix shell nixpkgs#uv --command uv run pytest` → 58/58 passing.
- `nix shell nixpkgs#uv --command uv build` → `dist/oaipmh-3.0.1-py3-none-any.whl` + `dist/oaipmh-3.0.1.tar.gz`.
- Built `PKG-INFO` (sdist) and `METADATA` (wheel) both now contain:
  - `Description-Content-Type: text/markdown`
  - Embedded README body starting with `# oaipmh` and the full badges / installation / "Why this fork" sections.

## Post-merge release sequence

Rebase-merge → annotated tag `v3.0.1` on the merge commit → draft GitHub Release → `publish.yml` fires → `pypi` environment reviewer gate → OIDC token → upload to PyPI under the `eth-library` organization.

## Test plan

- [x] `uv run pytest` green locally (58/58)
- [x] `uv build` succeeds and produces `3.0.1` artifacts
- [x] Built `PKG-INFO` / `METADATA` include `Description-Content-Type: text/markdown` and embedded README
- [x] CI green on PR
- [x] Post-publish: https://pypi.org/project/oaipmh/3.0.1/ renders the README body
- [x] Post-publish: fresh-venv `pip install oaipmh==3.0.1` + `import oaipmh.client` succeeds