### PR TITLE
feat: add Python 3.14 to the supported matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v6.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Python 3.14 support: added to the CI matrix and to the `pyproject.toml`
+  trove classifiers.
+
 ## [3.0.1] — 2026-04-15
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "License :: OSI Approved :: BSD License",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Environment :: Web Environment",


### PR DESCRIPTION
## Summary

Add [Python 3.14](https://www.python.org/downloads/release/python-3140/) (released October 2025) to the CI matrix and to the `pyproject.toml` trove classifiers. See [What's New in Python 3.14](https://docs.python.org/3/whatsnew/3.14.html) for the language-level changes. No runtime code changes in this PR.

- `.github/workflows/ci.yml`: append `"3.14"` to the existing matrix.
- `pyproject.toml`: add `Programming Language :: Python :: 3.14`.
- `CHANGELOG.md`: open `## [Unreleased]` with an `### Added` entry.

## Verification

Ran the suite locally on 3.14 via `uv`:

    uv run --python 3.14 pytest
    # 58 passed