### PR TITLE
ci: pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.0.0
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
 
       - name: Install Python ${{ matrix.python-version }} and dependencies
         run: uv sync --python ${{ matrix.python-version }} --extra test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,16 +10,16 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.0.0
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
 
       - name: Build distribution
         run: uv build
 
       - name: Upload distribution artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: dist
           path: dist/
@@ -38,10 +38,10 @@ jobs:
 
     steps:
       - name: Download distribution artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: dist
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0


### PR DESCRIPTION
## Summary

Pin every third-party action reference in `.github/workflows/ci.yml` and `.github/workflows/publish.yml` to a full 40-character commit SHA, with a trailing `# vX.Y.Z` comment so the intended release stays human-readable. This is the [recommended supply-chain posture](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) for GitHub Actions.

## Pins

| Action | Tag | Commit SHA |
|---|---|---|
| `actions/checkout` | `v6.0.2` | `de0fac2e4500dabe0009e67214ff5f5447ce83dd` |
| `astral-sh/setup-uv` | `v8.0.0` | `cec208311dfd045dd5311c1add060b2062131d57` |
| `actions/upload-artifact` | `v4.6.2` | `ea165f8d65b6e75b540449e92b4886f43607fa02` |
| `actions/download-artifact` | `v4.3.0` | `d3f86a106a0bac45b974a628896c90dbdf5c8093` |
| `pypa/gh-action-pypi-publish` | `v1.14.0` | `cef221092ed1bacb1cc03d23a2d87d1d172e277b` |

The floating `@release/v1` reference on `pypa/gh-action-pypi-publish` is replaced with the most recent stable `v1.Y.Z` tag, whose annotated tag object is GPG-signed by the PyPA maintainer.

For the `v4`-series artifact actions, the previous `@v4` floating tag currently resolves to `v4.6.2` (upload) and `v4.3.0` (download) respectively — behavior is unchanged.