### PR TITLE
ci: enable Dependabot for github-actions and uv ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,37 @@
+version: 2
+
+updates:
+  # GitHub Actions: SHA-pinned `uses:` references in workflow files.
+  # Mechanical updates; group them into a single PR per week.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "main"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+    labels:
+      - "dependencies"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  # Python dependencies managed by uv (pyproject.toml + uv.lock).
+  # Dependabot's native `uv` ecosystem regenerates `uv.lock` as part of
+  # each PR. Group patch + minor bumps into a single PR; leave majors
+  # ungrouped so each one lands as its own PR for scrutiny.
+  - package-ecosystem: "uv"
+    directory: "/"
+    target-branch: "main"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+    labels:
+      - "dependencies"
+    groups:
+      python-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary

Introduce `.github/dependabot.yml` to keep GitHub Actions and Python dependencies current on a weekly cadence.

## Ecosystems

### `github-actions`

One grouped weekly PR covering every pending action bump. Grouping is safe because every `uses:` reference in `ci.yml` and `publish.yml` is SHA-pinned with a trailing `# vX.Y.Z` comment (see the companion `ci/pin-actions-by-sha` change): each bump is a mechanical SHA rotation with a matching version-comment update, and the workflows themselves cover correctness.

### `uv`

Dependabot's [native `uv` ecosystem](https://docs.github.com/en/code-security/dependabot/ecosystems-supported-by-dependabot/supported-ecosystems-and-repositories) — now GA — reads `pyproject.toml` and regenerates `uv.lock` as part of each update PR. This is preferable to `package-ecosystem: "pip"`, which would leave `uv.lock` out of date after each bump.

Grouping strategy:

- **Minor and patch** bumps are grouped into one weekly PR. These are low-risk and routine, and batching them avoids PR churn.
- **Major** bumps are intentionally left ungrouped so each one lands in its own PR and can be reviewed on its merits. This matches the library's posture of stability for downstream consumers.

## Conventions

- `schedule.interval: "weekly"` — cadence matches the [Dependabot options reference](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference).
- `commit-message.prefix: "chore"` — aligns with the repository's [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) style.
- `labels: ["dependencies"]` — default label so Dependabot PRs are easy to filter.
- No `open-pull-requests-limit` — grouping already bounds the volume; an arbitrary cap would hide updates instead of organising them.
