### PR TITLE
perf(ci): tune Nix-store and uv-wheel caches; centralise via composites

### DIFF
--- a/.github/actions/setup-nix-cache/action.yml
+++ b/.github/actions/setup-nix-cache/action.yml
@@ -1,0 +1,28 @@
+name: Set up Nix with store cache
+description: >-
+  Install Nix and restore the per-job Nix store cache. Wraps
+  cachix/install-nix-action and nix-community/cache-nix-action so that
+  workflow callers see a single step pair with one input.
+
+inputs:
+  job-name:
+    description: >-
+      Job-scope discriminator folded into the cache key (e.g. `lint`,
+      `matrix`, `test-py312`, `build`). Required; no default.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Install Nix
+      uses: cachix/install-nix-action@ab739621df7a23f52766f9ccc97f38da6b7af14f # v31.10.5
+      with:
+        extra_nix_config: |
+          experimental-features = nix-command flakes
+
+    - name: Cache Nix store
+      uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7.0.2
+      with:
+        primary-key: nix-${{ runner.os }}-${{ inputs.job-name }}-${{ hashFiles('flake.lock') }}-${{ hashFiles('.github/actions/setup-nix-cache/action.yml') }}
+        restore-prefixes-first-match: |
+          nix-${{ runner.os }}-${{ inputs.job-name }}-${{ hashFiles('flake.lock') }}-

--- a/.github/actions/setup-uv-cache/action.yml
+++ b/.github/actions/setup-uv-cache/action.yml
@@ -1,0 +1,23 @@
+name: Set up uv wheel cache
+description: >-
+  Restore the uv wheel cache at `~/.cache/uv` keyed on `uv.lock` so that
+  `uv sync` reuses previously downloaded wheels across runs. Single
+  composite step around actions/cache.
+
+inputs:
+  python:
+    description: >-
+      Python-shell discriminator folded into the cache key (e.g.
+      `py312`, `default`). Required; no default.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Cache uv wheels
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      with:
+        path: ~/.cache/uv
+        key: uv-${{ runner.os }}-${{ inputs.python }}-${{ hashFiles('uv.lock') }}-${{ hashFiles('.github/actions/setup-uv-cache/action.yml') }}
+        restore-keys: |
+          uv-${{ runner.os }}-${{ inputs.python }}-${{ hashFiles('uv.lock') }}-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,19 +12,9 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Install Nix
-        uses: cachix/install-nix-action@ab739621df7a23f52766f9ccc97f38da6b7af14f # v31.10.5
+      - uses: ./.github/actions/setup-nix-cache
         with:
-          extra_nix_config: |
-            experimental-features = nix-command flakes
-
-      - name: Cache Nix store
-        uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7.0.2
-        with:
-          primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.lock') }}-${{ hashFiles('.github/workflows/ci.yml') }}
-          restore-prefixes-first-match: |
-            nix-${{ runner.os }}-${{ hashFiles('flake.lock') }}-
-            nix-${{ runner.os }}-
+          job-name: lint
 
       - name: Run pre-commit
         run: nix develop .#default --command pre-commit run --all-files --show-diff-on-failure
@@ -39,11 +29,9 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Install Nix
-        uses: cachix/install-nix-action@ab739621df7a23f52766f9ccc97f38da6b7af14f # v31.10.5
+      - uses: ./.github/actions/setup-nix-cache
         with:
-          extra_nix_config: |
-            experimental-features = nix-command flakes
+          job-name: matrix
 
       - name: Derive matrix from flake's exported shell list
         id: derive
@@ -63,22 +51,16 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Install Nix
-        uses: cachix/install-nix-action@ab739621df7a23f52766f9ccc97f38da6b7af14f # v31.10.5
+      - uses: ./.github/actions/setup-nix-cache
         with:
-          extra_nix_config: |
-            experimental-features = nix-command flakes
+          job-name: test-${{ matrix.python }}
 
-      - name: Cache Nix store
-        uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7.0.2
+      - uses: ./.github/actions/setup-uv-cache
         with:
-          primary-key: nix-${{ runner.os }}-${{ matrix.python }}-${{ hashFiles('flake.lock') }}-${{ hashFiles('.github/workflows/ci.yml') }}
-          restore-prefixes-first-match: |
-            nix-${{ runner.os }}-${{ matrix.python }}-${{ hashFiles('flake.lock') }}-
-            nix-${{ runner.os }}-${{ matrix.python }}-
+          python: ${{ matrix.python }}
 
       - name: Sync dependencies
-        run: nix develop .#${{ matrix.python }} --command uv sync --extra test
+        run: nix develop .#${{ matrix.python }} --command uv sync --frozen --extra test
 
       - name: Run tests
         run: nix develop .#${{ matrix.python }} --command uv run pytest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,19 +12,13 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Install Nix
-        uses: cachix/install-nix-action@ab739621df7a23f52766f9ccc97f38da6b7af14f # v31.10.5
+      - uses: ./.github/actions/setup-nix-cache
         with:
-          extra_nix_config: |
-            experimental-features = nix-command flakes
+          job-name: build
 
-      - name: Cache Nix store
-        uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7.0.2
+      - uses: ./.github/actions/setup-uv-cache
         with:
-          primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.lock') }}-${{ hashFiles('.github/workflows/publish.yml') }}
-          restore-prefixes-first-match: |
-            nix-${{ runner.os }}-${{ hashFiles('flake.lock') }}-
-            nix-${{ runner.os }}-
+          python: default
 
       - name: Build distribution
         run: nix develop .#default --command uv build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`publish.yml`). Pure-Python source semantics unchanged; published
   artifact bytes may differ across releases due to build-toolchain
   provenance.
+- Centralise CI cache wiring behind composite Actions in
+  `.github/actions/`; `test` and `build` now also cache
+  `~/.cache/uv`.
 
 ## [3.1.0] — 2026-04-23
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,10 +89,20 @@ lint                  (independent)
 matrix ──▶ test       (test: needs: matrix; fans out per devShell)
 ```
 
-- **Lint track** (`lint` job, independent) — runs `pre-commit run --all-files` over the repository. Same Ruff and hygiene hooks that run on every local commit.
-- **Test track** (`matrix` → `test`) — `matrix` evaluates `nix eval --json .#pythonShells` and exposes the devShell-name list as a job output; `test` depends on it (`needs: matrix`) and fans out one row per devShell with `fail-fast: false` so a regression on one row doesn't mask others. Adding or removing a Python version is a one-line edit to `pythonEntries` in `flake.nix`; CI follows automatically.
+### Jobs
 
-All three jobs run inside Nix devShells declared in `flake.nix`. CI's Python interpreter, `uv`, and `pre-commit` come from that file — the same source contributors use locally. Both `lint` and the `test` rows cache the Nix store between runs (`nix-community/cache-nix-action`); the `matrix` job is `nix eval`-only and skips caching for now.
+- **`lint`** (independent) — runs `pre-commit run --all-files` over the repository. Same Ruff and hygiene hooks that run on every local commit.
+- **`matrix` → `test`** — `matrix` evaluates `nix eval --json .#pythonShells` and exposes the devShell-name list as a job output; `test` depends on it (`needs: matrix`) and fans out one row per devShell with `fail-fast: false` so a regression on one row doesn't mask others. Adding or removing a Python version is a one-line edit to `pythonEntries` in `flake.nix`; CI follows automatically.
+- **`build`** (in `publish.yml`, runs only on `release: published`) — builds the sdist + wheel inside `nix develop .#default` for publication.
+
+All jobs run inside Nix devShells declared in `flake.nix`. CI's Python interpreter, `uv`, and `pre-commit` come from that file — the same source contributors use locally.
+
+### Composite Actions
+
+Cache wiring lives under `.github/actions/` so each workflow job calls one composite step instead of inlining the underlying Action pins:
+
+- **`setup-nix-cache`** — installs Nix and restores the per-job Nix store cache, keyed on `flake.lock`. Required input `job-name` scopes the cache per job (`lint`, `matrix`, `test-py3XX`, `build`).
+- **`setup-uv-cache`** — restores `~/.cache/uv` keyed on `uv.lock` so `uv sync` reuses previously downloaded wheels across runs. Required input `python` scopes the cache per devShell (`py3XX`, `default`).
 
 ## Style
 


### PR DESCRIPTION
Closes #23 — see the issue for motivation, goals, and acceptance criteria; this PR description scopes to what changed.

## Summary

- Adds `.github/actions/setup-nix-cache/` (input: `job-name`) wrapping [`cachix/install-nix-action`](https://github.com/cachix/install-nix-action) v31.10.5 then [`nix-community/cache-nix-action`](https://github.com/nix-community/cache-nix-action) v7.0.2.
- Adds `.github/actions/setup-uv-cache/` (input: `python`) wrapping [`actions/cache`](https://github.com/actions/cache) over `~/.cache/uv`.
- Routes `lint`, `matrix`, and each `test` row in `ci.yml` through `setup-nix-cache`; adds `setup-uv-cache` to `test`. `matrix` is now cached.
- Routes `publish.yml`'s `build` job through both composites with `python: default`. `publish` job untouched.
- Switches `uv sync --extra test` → `uv sync --frozen --extra test`.
- Drops the cross-job fallback restore prefix and the per-workflow `hashFiles(...)` term from primary keys.
- Each composite hashes its own `action.yml` into the key so cache-shape edits auto-invalidate.
- Updates `CONTRIBUTING.md`'s `## CI` section and adds a `[Unreleased]` `Changed` bullet to `CHANGELOG.md`.

All upstream Actions are SHA-pinned with trailing `# vX.Y.Z` comments.

## Test plan

- [x] `pre-commit run --all-files` exits 0 locally
- [x] Branch-push CI green on `lint`, `matrix`, and all five `test` rows
- [x] Post-merge `gh cache list` shows per-job key namespaces matching #23's targets