### PR TITLE
chore(precommit): add nix flake lock drift check hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,3 +22,12 @@ repos:
       - id: check-toml
       - id: check-merge-conflict
       - id: check-added-large-files
+
+  - repo: local
+    hooks:
+      - id: nix-flake-lock-check
+        name: nix flake lock drift check
+        entry: nix flake lock --no-update-lock-file
+        language: system
+        files: ^flake\.(nix|lock)$
+        pass_filenames: false


### PR DESCRIPTION

## Summary

Adds a local [`pre-commit`](https://pre-commit.com) hook that runs `nix flake lock --no-update-lock-file` whenever `flake.nix` or `flake.lock` is staged. The flag refreshes the lockfile only if it is already consistent with `flake.nix` and otherwise fails, so the hook surfaces flake-input drift at commit time instead of waiting for the next unconstrained lockfile regeneration. The hook is `language: system` with `pass_filenames: false` and a `^flake\.(nix|lock)$` file filter, so it only runs when those two files change and it relies on the `nix` binary already on the contributor's `PATH` (provided by the project's Nix devShell). No source code or runtime behaviour changes; the only edited file is `.pre-commit-config.yaml`.

## Test plan

- `uv run pytest` — unchanged; the test suite is untouched.
- `pre-commit run nix-flake-lock-check --all-files` exits 0 against the current `flake.nix` / `flake.lock` pair.
- Manually verified both ends of the contract:
  - **Drifted tree:** added a genuinely new input (`devshell.url = "github:numtide/devshell";`) to `flake.nix` so the file parses but `flake.lock` no longer matches → `nix flake lock --no-update-lock-file` exits 1 with `error: flake '…' requires lock file changes but they're not allowed due to '--no-update-lock-file'`; the hook fails.
  - **Clean tree (post-revert):** unmodified `flake.nix` / `flake.lock` → hook passes.
- Branch-push CI: the existing `lint` job (which already runs `pre-commit run --all-files`) picks the new hook up automatically and runs it across the matrix.

## Checklist

- [x] Tests green locally (`uv run pytest`)
- [x] `pre-commit run --all-files` exits 0

