### PR TITLE
client: raise RateLimitedError on HTTP 429 with parsed Retry-After

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `client.RateLimitedError` (subclass of `client.Error`) raised on HTTP
+  429 responses from `retrieveFromUrlWaiting()`. Carries
+  `retry_after_seconds` (parsed per RFC 9110 §10.2.3, accepting both
+  delta-seconds and HTTP-date forms; `None` if missing/invalid),
+  `retry_after_raw` (the verbatim header value), `code` (always `429`),
+  `headers`, `url`, and `original_error` to ease migration for callers
+  previously matching on `urllib.error.HTTPError.code`. Raised via
+  `raise ... from e` so the original exception is preserved on
+  `__cause__`.
+- Internal `_parse_retry_after()` and `_get_response_header()` helpers
+  in `client.py` (the latter normalises `HTTPError.headers` vs `.hdrs`
+  across Python versions and is now used for the existing 503 path
+  too).
+
 ### Changed
 
+- HTTP 429 is now **always** raised as `RateLimitedError`, regardless
+  of `expected_errcodes`. Previously 429 fell through as
+  `urllib.error.HTTPError` and (if a caller added 429 to
+  `expected-errcodes`) could trigger an in-process `time.sleep` of the
+  full `Retry-After` value. Real-world 429s from sources like DOAB
+  OAPEN carry `Retry-After: 86400`, which would lock a worker for 24h
+  — surfacing as a typed exception lets callers persist deadlines or
+  escalate. 503 retry behaviour is unchanged.
 - Chain re-raised exceptions with `raise ... from` in `client.py`,
   `server.py`, and `datestamp.py` so tracebacks show the original cause
   ([Ruff `B904`](https://docs.astral.sh/ruff/rules/raise-without-from-inside-except/) /

--- a/src/oaipmh/client.py
+++ b/src/oaipmh/client.py
@@ -11,6 +11,8 @@ except ImportError:
 
 import base64
 import codecs
+import datetime
+import email.utils
 import time
 
 from lxml import etree
@@ -24,6 +26,95 @@ WAIT_MAX = 5
 
 class Error(Exception):
     pass
+
+
+class RateLimitedError(Error):
+    """Raised when the server returns HTTP 429 (Too Many Requests).
+
+    Carries the parsed ``Retry-After`` value so callers can decide their
+    own back-off strategy. We deliberately do NOT sleep inline for 429:
+    valid ``Retry-After`` values can be hours or days (e.g. DOAB OAPEN
+    sends 86400), which would lock a worker indefinitely.
+
+    Attributes
+    ----------
+    retry_after_seconds : int or None
+        ``Retry-After`` parsed per RFC 9110 §10.2.3 (delta-seconds OR
+        HTTP-date). ``None`` if the header was missing or unparseable.
+    retry_after_raw : str or None
+        The unmodified header value.
+    code : int
+        Always ``429``; mirrors :class:`urllib.error.HTTPError.code` to
+        ease migration for callers that previously matched on ``e.code``.
+    headers : Mapping or None
+        Response headers from the originating ``HTTPError``.
+    url : str or None
+        Request URL from the originating ``HTTPError``.
+    original_error : urllib.error.HTTPError or None
+        The exception we caught (also available as ``__cause__`` because
+        we ``raise ... from`` the original).
+    """
+
+    code = 429
+
+    def __init__(
+        self,
+        retry_after_seconds=None,
+        retry_after_raw=None,
+        message=None,
+        headers=None,
+        url=None,
+        original_error=None,
+    ):
+        self.retry_after_seconds = retry_after_seconds
+        self.retry_after_raw = retry_after_raw
+        self.headers = headers
+        self.url = url
+        self.original_error = original_error
+        super().__init__(message or "rate limited (HTTP 429)")
+
+
+def _parse_retry_after(raw):
+    """Parse ``Retry-After`` per RFC 9110 §10.2.3.
+
+    Returns an int number of seconds (>= 0), or ``None`` if the value is
+    missing or cannot be parsed. Accepts both forms:
+
+    - delta-seconds: ``"86400"`` (negative or non-numeric → ``None``)
+    - HTTP-date:     ``"Wed, 21 Oct 2099 07:28:00 GMT"`` (past → ``0``)
+    """
+    if not raw:
+        return None
+    raw = raw.strip()
+    try:
+        seconds = int(raw)
+    except ValueError:
+        seconds = None
+    if seconds is not None:
+        if seconds < 0:
+            return None
+        return seconds
+    try:
+        target = email.utils.parsedate_to_datetime(raw)
+    except (TypeError, ValueError):
+        return None
+    if target is None:
+        return None
+    if target.tzinfo is None:
+        target = target.replace(tzinfo=datetime.timezone.utc)
+    now = datetime.datetime.now(datetime.timezone.utc)
+    return max(0, int((target - now).total_seconds()))
+
+
+def _get_response_header(http_error, name):
+    """Read a header from an HTTPError across Python versions.
+
+    Newer Python exposes ``HTTPError.headers``; older code uses ``.hdrs``.
+    """
+    headers = getattr(http_error, "headers", None) or getattr(http_error, "hdrs", None)
+    if headers is None:
+        return None
+    return headers.get(name)
 
 
 class BaseClient(common.OAIPMH):
@@ -398,7 +489,15 @@ def retrieveFromUrlWaiting(
     wait_default=WAIT_DEFAULT,
     expected_errcodes={503},  # noqa: B006  # public API; mutating the default would be a caller bug, behaviour-preserving fix deferred
 ):
-    """Get text from URL, handling 503 Retry-After."""
+    """Get text from URL, handling 503 Retry-After in-process.
+
+    HTTP 429 responses are *always* raised as :class:`RateLimitedError`
+    with ``Retry-After`` parsed and exposed on the exception (regardless
+    of ``expected_errcodes``). Callers must decide their own 429
+    strategy: valid ``Retry-After`` values can be hours or days, which
+    would lock the worker if slept inline. Surfacing as data lets
+    callers persist deadlines, skip work, or escalate.
+    """
     for _i in list(range(wait_max)):
         try:
             f = urllib2.urlopen(request)
@@ -407,9 +506,18 @@ def retrieveFromUrlWaiting(
             # we successfully opened without having to wait
             break
         except urllib2.HTTPError as e:
+            if e.code == 429:
+                raw = _get_response_header(e, "Retry-After")
+                raise RateLimitedError(
+                    retry_after_seconds=_parse_retry_after(raw),
+                    retry_after_raw=raw,
+                    headers=getattr(e, "headers", None) or getattr(e, "hdrs", None),
+                    url=getattr(e, "url", None),
+                    original_error=e,
+                ) from e
             if e.code in expected_errcodes:
                 try:
-                    retryAfter = int(e.hdrs.get("Retry-After"))
+                    retryAfter = int(_get_response_header(e, "Retry-After"))
                 except TypeError:
                     retryAfter = None
                 if retryAfter is None:

--- a/src/oaipmh/tests/test_client.py
+++ b/src/oaipmh/tests/test_client.py
@@ -16,8 +16,8 @@ fakeclient = FakeClient(fake1)
 fakeclient.getMetadataRegistry().registerReader("oai_dc", metadata.oai_dc_reader)
 
 
-def http_error(code):
-    return urllib2.HTTPError("mock-url", code, "error", {}, None)
+def http_error(code, headers=None):
+    return urllib2.HTTPError("mock-url", code, "error", headers or {}, None)
 
 
 class ClientTestCase(TestCase):
@@ -191,3 +191,99 @@ class ClientTestCase(TestCase):
                     )
                 self.assertEqual(sleep.call_count, 5)
                 sleep.assert_has_calls([mock.call(5)] * 5)
+
+    def test_429_raises_rate_limited_error_with_parsed_retry_after(self):
+        """HTTP 429 raises RateLimitedError; Retry-After delta-seconds parsed."""
+        err = http_error(429, headers={"Retry-After": "86400"})
+        with mock.patch(URLOPEN_PATH, side_effect=err):  # noqa: SIM117
+            with mock.patch("time.sleep") as sleep:
+                urlclient = client.Client("http://mock.me")
+                with self.assertRaises(client.RateLimitedError) as ctx:
+                    urlclient.listRecords(
+                        from_=datetime(2003, 4, 10), metadataPrefix="oai_dc"
+                    )
+        self.assertEqual(ctx.exception.code, 429)
+        self.assertEqual(ctx.exception.retry_after_seconds, 86400)
+        self.assertEqual(ctx.exception.retry_after_raw, "86400")
+        # Critical: 429 must NOT trigger in-process sleep.
+        sleep.assert_not_called()
+        # Migration attributes preserve everything urllib's HTTPError carried.
+        self.assertIs(ctx.exception.original_error, err)
+        self.assertEqual(ctx.exception.url, "mock-url")
+        self.assertIsNotNone(ctx.exception.headers)
+        # raise ... from e preserves cause chain (PEP 3134).
+        self.assertIs(ctx.exception.__cause__, err)
+
+    def test_429_raises_even_when_in_expected_errcodes(self):
+        """429 always raises RateLimitedError; expected_errcodes can't override."""
+        err = http_error(429, headers={"Retry-After": "60"})
+        with mock.patch(URLOPEN_PATH, side_effect=err):  # noqa: SIM117
+            with mock.patch("time.sleep") as sleep:
+                urlclient = client.Client(
+                    "http://mock.me",
+                    custom_retry_policy={"expected-errcodes": {429, 503}},
+                )
+                with self.assertRaises(client.RateLimitedError):
+                    urlclient.listRecords(
+                        from_=datetime(2003, 4, 10), metadataPrefix="oai_dc"
+                    )
+        sleep.assert_not_called()
+
+    def test_429_http_date_retry_after(self):
+        """RFC 9110 allows HTTP-date form; parses to (positive) seconds."""
+        err = http_error(429, headers={"Retry-After": "Wed, 21 Oct 2099 07:28:00 GMT"})
+        with mock.patch(URLOPEN_PATH, side_effect=err):
+            urlclient = client.Client("http://mock.me")
+            with self.assertRaises(client.RateLimitedError) as ctx:
+                urlclient.listRecords(
+                    from_=datetime(2003, 4, 10), metadataPrefix="oai_dc"
+                )
+        self.assertIsNotNone(ctx.exception.retry_after_seconds)
+        self.assertGreater(ctx.exception.retry_after_seconds, 0)
+        self.assertEqual(ctx.exception.retry_after_raw, "Wed, 21 Oct 2099 07:28:00 GMT")
+
+    def test_429_missing_retry_after(self):
+        """Missing Retry-After header -> retry_after_seconds is None."""
+        err = http_error(429, headers={})
+        with mock.patch(URLOPEN_PATH, side_effect=err):
+            urlclient = client.Client("http://mock.me")
+            with self.assertRaises(client.RateLimitedError) as ctx:
+                urlclient.listRecords(
+                    from_=datetime(2003, 4, 10), metadataPrefix="oai_dc"
+                )
+        self.assertIsNone(ctx.exception.retry_after_seconds)
+        self.assertIsNone(ctx.exception.retry_after_raw)
+
+    def test_429_invalid_retry_after(self):
+        """Unparseable Retry-After -> retry_after_seconds is None, raw preserved."""
+        err = http_error(429, headers={"Retry-After": "not a number"})
+        with mock.patch(URLOPEN_PATH, side_effect=err):
+            urlclient = client.Client("http://mock.me")
+            with self.assertRaises(client.RateLimitedError) as ctx:
+                urlclient.listRecords(
+                    from_=datetime(2003, 4, 10), metadataPrefix="oai_dc"
+                )
+        self.assertIsNone(ctx.exception.retry_after_seconds)
+        self.assertEqual(ctx.exception.retry_after_raw, "not a number")
+
+    def test_429_negative_retry_after_treated_as_invalid(self):
+        """Negative delta-seconds is malformed per RFC 9110 -> None."""
+        err = http_error(429, headers={"Retry-After": "-5"})
+        with mock.patch(URLOPEN_PATH, side_effect=err):
+            urlclient = client.Client("http://mock.me")
+            with self.assertRaises(client.RateLimitedError) as ctx:
+                urlclient.listRecords(
+                    from_=datetime(2003, 4, 10), metadataPrefix="oai_dc"
+                )
+        self.assertIsNone(ctx.exception.retry_after_seconds)
+
+    def test_429_http_date_in_past_clamped_to_zero(self):
+        """Past HTTP-date clamps to 0 (the deadline has already passed)."""
+        err = http_error(429, headers={"Retry-After": "Wed, 21 Oct 2001 07:28:00 GMT"})
+        with mock.patch(URLOPEN_PATH, side_effect=err):
+            urlclient = client.Client("http://mock.me")
+            with self.assertRaises(client.RateLimitedError) as ctx:
+                urlclient.listRecords(
+                    from_=datetime(2003, 4, 10), metadataPrefix="oai_dc"
+                )
+        self.assertEqual(ctx.exception.retry_after_seconds, 0)


### PR DESCRIPTION
Closes #28. Replaces #27 (closed; that one was prepared against `infrae/pyoai` conventions and didn't fit this fork).

## Why

`oaipmh.client.retrieveFromUrlWaiting()` re-raises `urllib.error.HTTPError` on HTTP 429 and only treats 503 as retry-worthy. The default 503 path calls `time.sleep(retryAfter)`, which is wrong for 429 — valid `Retry-After` values are commonly hours or days. DOAB OAPEN sends `Retry-After: 86400`, which would lock a worker for 24h if slept inline. Today, callers have to manually catch `HTTPError`, inspect `e.code == 429`, and reimplement RFC 9110 §10.2.3 parsing. Surfacing 429 as a typed exception with parsed `retry_after_seconds` lets consumers build deadline-respecting back-off (cross-cron sentinel, persistent deadline, circuit breaker) without that boilerplate.

## What

- New `client.RateLimitedError(client.Error)` carrying:
  - `retry_after_seconds: int | None` — RFC 9110 §10.2.3 parse of `Retry-After`, accepting both delta-seconds (`"86400"`) and HTTP-date (`"Wed, 21 Oct 2099 07:28:00 GMT"`). Returns `None` if missing/invalid/negative; past HTTP-date clamps to `0`.
  - `retry_after_raw: str | None` — verbatim header value.
  - `code = 429`, plus `headers`, `url`, `original_error` to mirror what `HTTPError` carried (eases migration for callers that previously matched on `e.code`).
- `retrieveFromUrlWaiting()` raises `RateLimitedError` on 429 **regardless** of `expected_errcodes` and uses `raise ... from e` so the original `HTTPError` is preserved on `__cause__` (PEP 3134 / Ruff B904).
- 503 retry behaviour unchanged. The existing 503 path now uses a small `_get_response_header()` helper that normalises `HTTPError.headers` vs `.hdrs`.
- `CHANGELOG.md` entry under `[Unreleased]` (Added + Changed sections).

## Breaking change

Callers that previously caught `urllib.error.HTTPError` on 429 must switch to `client.RateLimitedError`. The exception's `code`, `headers`, `url`, and `original_error` attributes mirror `HTTPError` to ease migration.

## Tests

- 7 new tests in `src/oaipmh/tests/test_client.py`:
  - immediate raise on 429 with parsed delta-seconds
  - `time.sleep` is **not** called on 429
  - `expected_errcodes` cannot suppress 429
  - HTTP-date `Retry-After` parses to positive seconds
  - missing header → `retry_after_seconds is None`
  - invalid header → `None`, raw preserved
  - negative delta-seconds → `None` (malformed per RFC 9110)
  - past HTTP-date clamps to `0`
- Full suite: 65/65 pass (`uv run pytest`).
- `ruff check` + `ruff format` clean; pre-commit hooks pass.

## Motivation

Real-world incident: DOAB OAPEN's `Retry-After: 86400` was silently stalling the OAI harvest for downstream consumers ([Gluejar/regluit#1143](https://github.com/Gluejar/regluit/issues/1143), [Gluejar/regluit#1144](https://github.com/Gluejar/regluit/issues/1144)). The app-level workaround (cross-cron sentinel) works but is uglier than it needs to be — surfacing the signal cleanly in `oaipmh` lets any consumer build the right back-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)