### PR TITLE
feat(client): typed 429/503/network exceptions with Retry-After parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `RateLimitedError`, `ServiceUnavailableError`, and `NetworkError`
+  exception classes for typed handling of HTTP 429, 503, and
+  transport-level failures. All three preserve existing `except`
+  catch sites via inheritance.
+- `max-inline-sleep` retry-policy key (default 300 s), configurable via `custom_retry_policy`; a 503 whose `Retry-After` exceeds the cap raises instead of sleeping inline.
+
 ### Changed
 
+- HTTP 429 raises `RateLimitedError` immediately instead of falling
+  through as a raw `HTTPError`.
+- `urllib.error.URLError` is caught and re-raised as `NetworkError`.
+- Replace `e.hdrs` with `e.headers` in `retrieveFromUrlWaiting()`.
 - Chain re-raised exceptions with `raise ... from` in `client.py`,
   `server.py`, and `datestamp.py` so tracebacks show the original cause
   ([Ruff `B904`](https://docs.astral.sh/ruff/rules/raise-without-from-inside-except/) /
@@ -25,6 +37,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Format `*.nix` files with `nixfmt-rfc-style` (RFC 166).
 - Add a local `treefmt` `pre-commit` hook that routes `*.nix` files
   through `nix fmt`.
+
+### Deprecated
+
+- Passing 429 or 503 in a caller-supplied `expected-errcodes` set
+  now emits `DeprecationWarning`; catch the typed exceptions instead.
 
 ## [3.1.0] — 2026-04-23
 

--- a/src/oaipmh/client.py
+++ b/src/oaipmh/client.py
@@ -12,6 +12,7 @@ except ImportError:
 import base64
 import codecs
 import time
+import warnings
 
 from lxml import etree
 
@@ -36,6 +37,8 @@ class BaseClient(common.OAIPMH):
         "retry": WAIT_MAX,
         # which HTTP codes are expected
         "expected-errcodes": {503},
+        # raise ServiceUnavailableError when Retry-After exceeds this cap (seconds)
+        "max-inline-sleep": 300,
     }
 
     def __init__(self, metadata_registry=None, custom_retry_policy=None):
@@ -45,6 +48,16 @@ class BaseClient(common.OAIPMH):
         self.retry_policy = self.default_retry_policy.copy()
         if custom_retry_policy is not None:
             self.retry_policy.update(custom_retry_policy)
+            if "expected-errcodes" in custom_retry_policy:
+                typed = {429, 503} & custom_retry_policy["expected-errcodes"]
+                if typed:
+                    codes = ", ".join(str(c) for c in sorted(typed))
+                    warnings.warn(
+                        f"expected-errcodes containing {codes} is deprecated; "
+                        f"catch RateLimitedError / ServiceUnavailableError instead",
+                        DeprecationWarning,
+                        stacklevel=2,
+                    )
 
     def updateGranularity(self):
         """Update the granularity setting dependent on that the server says."""
@@ -368,6 +381,7 @@ class Client(BaseClient):
                 wait_max=self.retry_policy["retry"],
                 wait_default=self.retry_policy["wait-default"],
                 expected_errcodes=self.retry_policy["expected-errcodes"],
+                max_inline_sleep=self.retry_policy["max-inline-sleep"],
             )
 
 
@@ -397,28 +411,53 @@ def retrieveFromUrlWaiting(
     wait_max=WAIT_MAX,
     wait_default=WAIT_DEFAULT,
     expected_errcodes={503},  # noqa: B006  # public API; mutating the default would be a caller bug, behaviour-preserving fix deferred
+    max_inline_sleep=300,
 ):
-    """Get text from URL, handling 503 Retry-After."""
+    """Get text from URL, handling retryable HTTP errors.
+
+    HTTP 429 always raises ``RateLimitedError`` (no inline sleep).
+    HTTP 503 (or other codes in *expected_errcodes*) sleeps and retries
+    unless ``Retry-After`` exceeds *max_inline_sleep*, in which case
+    ``ServiceUnavailableError`` is raised.
+    ``urllib.error.URLError`` is caught and re-raised as ``NetworkError``.
+    """
     for _i in list(range(wait_max)):
         try:
             f = urllib2.urlopen(request)
             text = f.read()
             f.close()
-            # we successfully opened without having to wait
             break
         except urllib2.HTTPError as e:
+            if e.code == 429:
+                raise error.RateLimitedError(
+                    e.url,
+                    e.code,
+                    e.reason,
+                    e.headers,
+                    e.fp,
+                ) from e
+
             if e.code in expected_errcodes:
                 try:
-                    retryAfter = int(e.hdrs.get("Retry-After"))
-                except TypeError:
+                    retryAfter = int(e.headers.get("Retry-After"))
+                except (TypeError, ValueError):
                     retryAfter = None
+                if retryAfter is not None and retryAfter > max_inline_sleep:
+                    raise error.ServiceUnavailableError(
+                        e.url,
+                        e.code,
+                        e.reason,
+                        e.headers,
+                        e.fp,
+                    ) from e
                 if retryAfter is None:
                     time.sleep(wait_default)
                 else:
                     time.sleep(retryAfter)
             else:
-                # reraise any other HTTP error
                 raise
+        except urllib2.URLError as e:
+            raise error.NetworkError(str(e.reason), url_error=e) from e
     else:
         raise Error(f"Waited too often (more than {wait_max} times)")
     return text

--- a/src/oaipmh/error.py
+++ b/src/oaipmh/error.py
@@ -1,3 +1,8 @@
+import urllib.error
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
+
+
 class ErrorBase(Exception):
     def oainame(self):
         name = self.__class__.__name__
@@ -70,3 +75,81 @@ class DatestampError(ClientError):
 
     def details(self):
         return f"An illegal datestamp was encountered: {self.datestamp}"
+
+
+class NetworkError(ClientError):
+    """A transport-level failure (DNS, connection refused, timeout)."""
+
+    def __init__(self, message, url_error=None):
+        self.url_error = url_error
+        super().__init__(message)
+
+    def details(self):
+        return f"Network error: {self}"
+
+
+# ---------------------------------------------------------------------------
+# HTTP retry-after exceptions
+#
+# These inherit from urllib.error.HTTPError so existing ``except HTTPError:``
+# catch sites continue to match.  Retry-After parsing follows RFC 9110
+# section 10.2.3 (delta-seconds and HTTP-date).
+# ---------------------------------------------------------------------------
+
+
+def _parse_retry_after(headers):
+    """Return (seconds: int | None, http_date: datetime | None, raw: str | None).
+
+    *headers* is an ``http.client.HTTPMessage`` (or compatible mapping).
+    """
+    raw = headers.get("Retry-After") if headers is not None else None
+    if raw is None:
+        return None, None, None
+
+    raw = raw.strip()
+
+    # Try delta-seconds first (integer).
+    try:
+        delta = int(raw)
+    except (ValueError, OverflowError):
+        pass
+    else:
+        if delta < 0:
+            return None, None, raw
+        return delta, None, raw
+
+    # Try HTTP-date (RFC 9110 section 5.6.7).
+    try:
+        http_date = parsedate_to_datetime(raw)
+    except (ValueError, TypeError, OverflowError):
+        return None, None, raw
+
+    if http_date.tzinfo is None:
+        http_date = http_date.replace(tzinfo=timezone.utc)
+
+    delta = int((http_date - datetime.now(timezone.utc)).total_seconds())
+    if delta < 0:
+        delta = 0
+    return delta, http_date, raw
+
+
+class HTTPRetryAfterError(urllib.error.HTTPError):
+    """An HTTP error carrying parsed ``Retry-After`` header data.
+
+    Subclasses: ``RateLimitedError`` (429), ``ServiceUnavailableError`` (503).
+    """
+
+    def __init__(self, url, code, msg, hdrs, fp):
+        super().__init__(url, code, msg, hdrs, fp)
+        seconds, http_date, raw = _parse_retry_after(self.headers)
+        self.retry_after_seconds = seconds
+        self.retry_after_http_date = http_date
+        self.retry_after_raw = raw
+
+
+class RateLimitedError(HTTPRetryAfterError):
+    """HTTP 429 Too Many Requests."""
+
+
+class ServiceUnavailableError(HTTPRetryAfterError):
+    """HTTP 503 Service Unavailable with Retry-After exceeding the inline-sleep cap."""

--- a/src/oaipmh/tests/test_retry.py
+++ b/src/oaipmh/tests/test_retry.py
@@ -1,0 +1,277 @@
+import urllib.error
+import urllib.request as urllib2
+import warnings
+from datetime import datetime, timedelta, timezone
+from unittest import TestCase, mock
+
+from oaipmh import client, error
+
+URLOPEN_PATH = "urllib.request.urlopen"
+
+
+def http_error(code, headers=None):
+    return urllib2.HTTPError(
+        "mock-url",
+        code,
+        "error",
+        headers or {},
+        None,
+    )
+
+
+def retry_after_exc(value):
+    """Build an HTTPRetryAfterError with a Retry-After header."""
+    hdrs = {"Retry-After": value} if value is not None else {}
+    return error.HTTPRetryAfterError(
+        "http://x",
+        503,
+        "Unavailable",
+        hdrs,
+        None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Layer 1: Exception class unit tests (no HTTP mocking)
+# ---------------------------------------------------------------------------
+
+
+class RetryAfterParsingTestCase(TestCase):
+    def test_retry_after_delta_seconds(self):
+        exc = retry_after_exc("120")
+        self.assertEqual(exc.retry_after_seconds, 120)
+        self.assertIsNone(exc.retry_after_http_date)
+
+    def test_retry_after_http_date(self):
+        future = datetime.now(timezone.utc) + timedelta(seconds=600)
+        date_str = future.strftime("%a, %d %b %Y %H:%M:%S GMT")
+        exc = retry_after_exc(date_str)
+        self.assertIsNotNone(exc.retry_after_seconds)
+        self.assertGreater(exc.retry_after_seconds, 0)
+        self.assertIsNotNone(exc.retry_after_http_date)
+
+    def test_retry_after_past_http_date(self):
+        past = datetime.now(timezone.utc) - timedelta(hours=1)
+        date_str = past.strftime("%a, %d %b %Y %H:%M:%S GMT")
+        exc = retry_after_exc(date_str)
+        self.assertEqual(exc.retry_after_seconds, 0)
+        self.assertIsNotNone(exc.retry_after_http_date)
+
+    def test_retry_after_missing(self):
+        exc = retry_after_exc(None)
+        self.assertIsNone(exc.retry_after_seconds)
+        self.assertIsNone(exc.retry_after_http_date)
+        self.assertIsNone(exc.retry_after_raw)
+
+    def test_retry_after_invalid(self):
+        exc = retry_after_exc("not-a-number")
+        self.assertIsNone(exc.retry_after_seconds)
+        self.assertIsNone(exc.retry_after_http_date)
+        self.assertEqual(exc.retry_after_raw, "not-a-number")
+
+    def test_retry_after_negative(self):
+        exc = retry_after_exc("-5")
+        self.assertIsNone(exc.retry_after_seconds)
+        self.assertIsNone(exc.retry_after_http_date)
+        self.assertEqual(exc.retry_after_raw, "-5")
+
+    def test_typed_exception_preserves_urllib_attributes(self):
+        hdrs = {"Retry-After": "60"}
+        exc = error.RateLimitedError(
+            "http://example.com",
+            429,
+            "Too Many Requests",
+            hdrs,
+            None,
+        )
+        self.assertEqual(exc.code, 429)
+        self.assertEqual(exc.url, "http://example.com")
+        self.assertEqual(exc.reason, "Too Many Requests")
+        self.assertEqual(exc.headers.get("Retry-After"), "60")
+
+    def test_rate_limited_is_http_error(self):
+        exc = error.RateLimitedError(
+            "http://x",
+            429,
+            "Too Many Requests",
+            {},
+            None,
+        )
+        self.assertIsInstance(exc, urllib.error.HTTPError)
+        self.assertIsInstance(exc, error.HTTPRetryAfterError)
+
+    def test_service_unavailable_is_http_error(self):
+        exc = error.ServiceUnavailableError(
+            "http://x",
+            503,
+            "Unavailable",
+            {},
+            None,
+        )
+        self.assertIsInstance(exc, urllib.error.HTTPError)
+        self.assertIsInstance(exc, error.HTTPRetryAfterError)
+
+    def test_network_error_is_client_error(self):
+        exc = error.NetworkError("DNS failed")
+        self.assertIsInstance(exc, error.ClientError)
+
+
+# ---------------------------------------------------------------------------
+# Layer 2: retrieveFromUrlWaiting() behaviour tests (HTTP mock)
+# ---------------------------------------------------------------------------
+
+
+class RetrieveRetryBehaviourTestCase(TestCase):
+    def test_429_raises_rate_limited(self):
+        side = http_error(429, {"Retry-After": "60"})
+        with (  # noqa: SIM117
+            mock.patch(URLOPEN_PATH, side_effect=side),
+            mock.patch("time.sleep") as sleep,
+        ):
+            with self.assertRaises(error.RateLimitedError) as ctx:
+                client.retrieveFromUrlWaiting(
+                    urllib2.Request("http://mock.me"),
+                )
+            sleep.assert_not_called()
+            self.assertIsInstance(
+                ctx.exception.__cause__,
+                urllib.error.HTTPError,
+            )
+
+    def test_429_bypasses_expected_errcodes(self):
+        side = http_error(429, {"Retry-After": "60"})
+        with (  # noqa: SIM117
+            mock.patch(URLOPEN_PATH, side_effect=side),
+            mock.patch("time.sleep") as sleep,
+        ):
+            with self.assertRaises(error.RateLimitedError):
+                client.retrieveFromUrlWaiting(
+                    urllib2.Request("http://mock.me"),
+                    expected_errcodes={429, 503},
+                )
+            sleep.assert_not_called()
+
+    def test_503_cap_boundary_matrix(self):
+        cases = [
+            ("below cap sleeps", "120", 300, True, 120),
+            ("exceeds cap raises", "600", 300, False, None),
+            ("at boundary sleeps", "300", 300, True, 300),
+            ("custom cap raises", "120", 60, False, None),
+        ]
+        for label, retry_after, cap, expect_sleep, sleep_val in cases:
+            with self.subTest(label):
+                side = http_error(503, {"Retry-After": retry_after})
+                with (
+                    mock.patch(URLOPEN_PATH, side_effect=side),
+                    mock.patch("time.sleep") as sleep,
+                ):
+                    if expect_sleep:
+                        with self.assertRaises(client.Error):
+                            client.retrieveFromUrlWaiting(
+                                urllib2.Request("http://mock.me"),
+                                wait_max=1,
+                                max_inline_sleep=cap,
+                            )
+                        sleep.assert_called_once_with(sleep_val)
+                    else:
+                        with self.assertRaises(error.ServiceUnavailableError):
+                            client.retrieveFromUrlWaiting(
+                                urllib2.Request("http://mock.me"),
+                                max_inline_sleep=cap,
+                            )
+                        sleep.assert_not_called()
+
+    def test_exhausted_retries_raises(self):
+        side = http_error(503, {"Retry-After": "1"})
+        with (  # noqa: SIM117
+            mock.patch(URLOPEN_PATH, side_effect=side),
+            mock.patch("time.sleep"),
+        ):
+            with self.assertRaises(client.Error, msg="Waited too often"):
+                client.retrieveFromUrlWaiting(
+                    urllib2.Request("http://mock.me"),
+                    wait_max=2,
+                    max_inline_sleep=300,
+                )
+
+    def test_urlerror_raises_network_error(self):
+        url_err = urllib.error.URLError("DNS lookup failed")
+        with (  # noqa: SIM117
+            mock.patch(URLOPEN_PATH, side_effect=url_err),
+            mock.patch("time.sleep") as sleep,
+        ):
+            with self.assertRaises(error.NetworkError) as ctx:
+                client.retrieveFromUrlWaiting(
+                    urllib2.Request("http://mock.me"),
+                )
+            sleep.assert_not_called()
+            self.assertIs(ctx.exception.__cause__, url_err)
+
+    def test_urlerror_mid_retry(self):
+        url_err = urllib.error.URLError("connection reset")
+        effects = [
+            http_error(503, {"Retry-After": "1"}),
+            url_err,
+        ]
+        with (  # noqa: SIM117
+            mock.patch(URLOPEN_PATH, side_effect=effects),
+            mock.patch("time.sleep"),
+        ):
+            with self.assertRaises(error.NetworkError) as ctx:
+                client.retrieveFromUrlWaiting(
+                    urllib2.Request("http://mock.me"),
+                    wait_max=5,
+                )
+            self.assertIs(ctx.exception.__cause__, url_err)
+
+
+# ---------------------------------------------------------------------------
+# Layer 3: Client-level tests (deprecation + construction)
+# ---------------------------------------------------------------------------
+
+
+class DeprecationWarningTestCase(TestCase):
+    def test_deprecation_429_in_expected(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            client.Client(
+                "http://mock.me",
+                custom_retry_policy={
+                    "expected-errcodes": {429},
+                },
+            )
+        dep = [x for x in w if issubclass(x.category, DeprecationWarning)]
+        self.assertEqual(len(dep), 1)
+        self.assertIn("429", str(dep[0].message))
+
+    def test_deprecation_503_in_expected(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            client.Client(
+                "http://mock.me",
+                custom_retry_policy={
+                    "expected-errcodes": {503},
+                },
+            )
+        dep = [x for x in w if issubclass(x.category, DeprecationWarning)]
+        self.assertEqual(len(dep), 1)
+        self.assertIn("503", str(dep[0].message))
+
+    def test_no_deprecation_default(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            client.Client("http://mock.me")
+        dep = [x for x in w if issubclass(x.category, DeprecationWarning)]
+        self.assertEqual(len(dep), 0)
+
+    def test_no_deprecation_non_typed(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            client.Client(
+                "http://mock.me",
+                custom_retry_policy={
+                    "expected-errcodes": {500},
+                },
+            )
+        dep = [x for x in w if issubclass(x.category, DeprecationWarning)]
+        self.assertEqual(len(dep), 0)


### PR DESCRIPTION

## Summary

`retrieveFromUrlWaiting()` had four error-handling gaps: HTTP 429 fell through as a raw `HTTPError` with no typed signal ([#28](https://github.com/eth-library/oaipmh/issues/28)), HTTP 503 with a large `Retry-After` value could block a worker indefinitely, `URLError` (DNS/connection/timeout) was uncaught, and the function used the undocumented `.hdrs` attribute instead of `.headers`.

This PR adds three exception classes — `RateLimitedError` (429), `ServiceUnavailableError` (503), and `NetworkError` (transport failures) — and reworks the function's error path:

- **429** always raises `RateLimitedError`. Callers receive parsed [`Retry-After`](https://www.rfc-editor.org/rfc/rfc9110#section-10.2.3) data (delta-seconds and HTTP-date formats) and decide how to back off.
- **503** with `Retry-After` at or below `max-inline-sleep` (default 300 s, tunable via `custom_retry_policy`) continues the existing sleep-and-retry loop. Values above the cap raise `ServiceUnavailableError` instead of blocking the worker.
- **`URLError`** is caught and re-raised as `NetworkError(ClientError)`, chained via `raise ... from e` ([PEP 3134](https://peps.python.org/pep-3134/)).
- All HTTP-level exceptions inherit from [`urllib.error.HTTPError`](https://docs.python.org/3/library/urllib.error.html#urllib.error.HTTPError), so existing `except HTTPError:` catch sites are unaffected. No new required constructor parameters.
- A [`DeprecationWarning`](https://docs.python.org/3/library/warnings.html) is emitted when caller-supplied `expected_errcodes` includes 429 or 503, pointing callers toward the typed exceptions.

Replaces `e.hdrs.get(...)` with `e.headers.get(...)` (the [documented Python 3 attribute](https://docs.python.org/3/library/urllib.error.html#urllib.error.HTTPError.headers)).

Closes #32. Supersedes the narrower 429 fix in #30 and closes #28.

## Test plan

- `uv run pytest` — 20 new tests in `test_retry.py` covering three layers:
  - **Exception parsing** (10 tests): `Retry-After` delta-seconds, HTTP-date, past date, missing, invalid, negative; `isinstance` checks for the inheritance hierarchy; standard `HTTPError` attribute preservation.
  - **Retry behavior** (7 tests): 429 raises without sleeping, 429 bypasses `expected_errcodes`, 503 cap boundary matrix (below/at/above/custom cap), `URLError` catch and mid-retry, retry-loop exhaustion.
  - **Deprecation warnings** (4 tests, constructed via `Client()` with `custom_retry_policy`): 429-in-set warns, 503-in-set warns, default-no-warn, non-typed-no-warn.
- Three existing retry-policy tests in `test_client.py` pass unmodified — verifies backward compatibility of the 503 sleep-and-retry path.
- CI matrix: all Python rows (3.10 -- 3.14); no version-sensitive behavior.
- The test plan verifies the acceptance criteria listed in #32.

## Checklist

- [x] Tests green locally (`uv run pytest`)

